### PR TITLE
Ability to save/load units preference

### DIFF
--- a/display/main_voyager.lisp
+++ b/display/main_voyager.lisp
@@ -1,7 +1,6 @@
 ; includes
 (define lisp_V 1.50)
 (define THR_TIMEOUT 2.5) ; 5 for 160Mhz
-(def UNITS 0); 0--> imperial 1--> metric
 
 (def mac_0 0)
 (def mac_1 0)
@@ -80,6 +79,7 @@
 (def time_since_screen_update 0)
 (def SCREEN_REFRESH_INTERVAL 100) ; 100ms = 10Hz
 
+(def units 0)
 (def direction 1)
 (def menu_index 0)
 (def main_prescaler 0)
@@ -119,6 +119,7 @@
 (setq pulley_config (to-float (eeprom-read-f pulley_add))) ; load default pulley value
 (setq batt_type_config (to-i (eeprom-read-i batt_type_add))) ; load default batt_type
 (setq safety_status (to-i (eeprom-read-i safety_status_add))) ; load the safety status for throttle
+(setq units (to-i (eeprom-read-i units_add))) ; load the units
 
 (esp_now_init)
 

--- a/display/res/eeprom_init.lisp
+++ b/display/res/eeprom_init.lisp
@@ -19,6 +19,7 @@
 (define pulley_add      18)
 (define batt_type_add   19)
 (define safety_status_add 20)
+(define units_add 21)
 
 ; Default values
 (define default_min_cal 100) ; Default based on typical production remotes
@@ -37,6 +38,7 @@
 (define default_s_count 18)
 (define default_safety_switch 0)
 (define init_flag 0xFFFE) ; Switched to 0xFFFE for v1.50 release to load new defaults
+(define default_units 0) ; Default to Imperial (0 = Imperial, 1 = Metric)
 
 (defun eeprom_check(){
     (setq test_value (to-i (eeprom-read-i 1))) ; Calibration (Min)
@@ -134,12 +136,17 @@
         (print "eeprom 20 error (safety status), writing default: 0")
         (eeprom-store-i 20 default_safety_switch)
     })
+    (setq test_value (to-i (eeprom-read-i 21))) ; Units
+    (if(or (< test_value 0)(> test_value 1)){
+        (print "eeprom 21 error, writing default")
+        (eeprom-store-i 21 default_units)
+    })
 })
 
 (defun eeprom_init(){
 
     (setq test_value (to-i (eeprom-read-i 32)))
-    
+
     ; MEMORY NOT INITIALIZED
     (if(< test_value init_flag){
             (print "Memory not initialized, writing default values")
@@ -163,7 +170,7 @@
             (eeprom-store-f 18 default_gear_ratio) ; Gear Ratio
             (eeprom-store-i 19 default_s_count) ; S-Count
             (eeprom-store-i 20 default_safety_switch) ; Safety Switch
-            (eeprom-store-i 21 0)
+            (eeprom-store-i 21 default_units) ; Units
             (eeprom-store-i 22 0)
             (eeprom-store-i 23 0)
             (eeprom-store-i 24 0)
@@ -192,7 +199,7 @@
             (eeprom-store-f 18 default_gear_ratio) ; Gear Ratio
             (eeprom-store-i 19 default_s_count) ; S-Count
             (eeprom-store-i 20 default_safety_switch) ; Safety Switch
-            (eeprom-store-i 21 0)
+            (eeprom-store-i 21 default_units) ; Units
             (eeprom-store-i 22 0)
             (eeprom-store-i 23 0)
             (eeprom-store-i 24 0)

--- a/display/screens/main_screen.lisp
+++ b/display/screens/main_screen.lisp
@@ -99,14 +99,14 @@
     ;; ;;;;;;;;;; ;;
 
     ;; SPEED ;;
-    (def current_speed (if (= UNITS 1) (speed_cal) (* (speed_cal) 0.621)))
+    (def current_speed (if (= units 1) (speed_cal) (* (speed_cal) 0.621)))
 
     (def current_display_speed (to-i (* current_speed 10)))  ; For comparing displayed values
     (if (or (!= current_display_speed last_displayed_speed)
             (!= speed_color last_speed_color)
             (= first_draw 1))
         (progn
-            (write-speed current_speed UNITS (+ x_offset (if (= UNITS 1) 33 28)) (+ y_offset 19) speed_color)
+            (write-speed current_speed units (+ x_offset (if (= units 1) 33 28)) (+ y_offset 19) speed_color)
             (setq last_displayed_speed current_display_speed)
             (setq last_speed_color speed_color)
         )
@@ -114,13 +114,13 @@
     ;; ;;;;; ;;
 
     ;; TRIP ;;
-    (def current_trip (if (= UNITS 1) distance (* distance 0.621)))
+    (def current_trip (if (= units 1) distance (* distance 0.621)))
 
     (def current_display_trip (to-i (* current_trip 10)))  ; For comparing displayed values
     (if (or (!= current_display_trip last_displayed_trip)
             (= first_draw 1))
         (progn
-            (write_trip current_trip UNITS (+ x_offset 63) (+ y_offset 50))
+            (write_trip current_trip units (+ x_offset 63) (+ y_offset 50))
             (setq last_displayed_trip current_display_trip)
         )
     )

--- a/display/screens/remote_screen.lisp
+++ b/display/screens/remote_screen.lisp
@@ -1,6 +1,8 @@
 (def firts_iteration_remote 0)
 (def remote_screen_num 0)
+(def thum_stick_prescaler 0)
 (def distance_total 0.0)
+
 @const-start
 (defun remote_screen(){
     (if (= firts_iteration_remote 0){
@@ -12,9 +14,8 @@
         (def text_box_2 (img-buffer 'indexed2 40 14))
         (def numb_box (img-buffer 'indexed2 120 30))
         (setq firts_iteration_remote 1)
-           
     })
-    
+
     (cond
         ((eq remote_screen_num 0) (progn
             (txt-block-l text_box 1 0 0  font_9x14 "MAC address")
@@ -63,12 +64,12 @@
             (txt-block-l text_box 1 0 0  font_9x14 "Units")
             (disp-render text_box (+ x_offset 1) (+ y_offset -1) '(0 0xFFFFFF))
             (img-clear text_box)
-            
-            (if (= UNITS 1) 
+
+            (if (= units 1)
                 (txt-block-c numb_box 1 60 0  font_20x30 "METRIC");
                 (txt-block-c numb_box 1 60 0  font_20x30 "IMPERIAL");
             )
-            
+
             (disp-render numb_box (+ x_offset 4) (+ y_offset 17) '(0 0xFFFFFF))
             (img-clear numb_box)
 
@@ -82,8 +83,8 @@
             (img-clear text_box)
             (setq distance_total (to-float (eeprom-read-f total_trip_add)))
             (setq distance_total (+ distance_total (if (= distance 0) 0 (/ distance 1000))))
-            (if (= UNITS 1)
-            { 
+            (if (= units 1)
+            {
                 (txt-block-c numb_box 1 60 0  font_20x30 (str-from-n distance_total "%0.1f"));
                 (txt-block-c text_box_2 1 20 0  font_9x14 "Km")
                 (disp-render text_box_2 (+ x_offset 47) (+ y_offset 44) '(0 0xFFFFFF))
@@ -98,11 +99,36 @@
             })
 
             (disp-render numb_box (+ x_offset 4) (+ y_offset 17) '(0 0xFFFFFF))
-            (img-clear numb_box)                  
-        
+            (img-clear numb_box)
+
         ))
     )
-    
+
+    ; adjust values with thumb stick
+    (setq thum_stick_prescaler (+ thum_stick_prescaler 1))
+    (if (and (> thum_stick_prescaler 10)){
+        ; thumb stick up
+        (if (> (get-adc 0) 2){
+            ; if on units screen, change units
+            (if (eq remote_screen_num 2){
+                (if (= units 0) (setq units 1) (setq units 0))
+                (eeprom-store-i units_add units)
+            })
+        })
+
+        ; thumb stick down
+        (if (< (get-adc 0) 0.8){
+            ; if on units screen, change units
+            (if (eq remote_screen_num 2){
+                (if (= units 0) (setq units 1) (setq units 0))
+                (eeprom-store-i units_add units)
+            })
+        })
+
+        (setq thum_stick_prescaler 0)
+    })
+
+    ; cycle through screens
     (if (= cfg_pressed_short 1){
         (setq cfg_pressed_short 0)
         (setq remote_screen_num (+ remote_screen_num 1))
@@ -111,16 +137,17 @@
         (if (> remote_screen_num 3)
             (setq remote_screen_num 0)
         )
-    }) 
-    
+    })
+
+    ; exit
     (if (= on_pressed_short 1){
-        (setq on_pressed_short 0) 
+        (setq on_pressed_short 0)
         (disp-clear)
         (setq firts_iteration 0)
         (setq menu_sub_index 0)
         (setq enter_menu 0)
         (setq firts_iteration_remote 0)
-        (setq remote_screen_num 0)       
-     })   
+        (setq remote_screen_num 0)
+     })
 })
 @const-start


### PR DESCRIPTION
This makes ~~two main changes~~ one change:

1. ~~Navigating in the `REMOTE` config menu is done with the thumbstick~~
    - ~~this makes it the same as the parent config menu~~
    - ~~I found it confusing that the menus worked differently~~
    - ~~it also means we can use the config button to edit the units~~
2. Allows changing the units in the `REMOTE` config menu
    - units are updated live in the remote
    - units are saved and loaded from the eeprom

I've tested this and so far it's working great. :+1: 

~~If it's alright with you I might create more PRs to go through and edit the other config menus so they're all navigated the same way, to avoid user confusion.~~